### PR TITLE
Bugfix see entries by date

### DIFF
--- a/src/main/java/seedu/duke/command/SeeAllEntriesCommand.java
+++ b/src/main/java/seedu/duke/command/SeeAllEntriesCommand.java
@@ -71,6 +71,12 @@ public class SeeAllEntriesCommand extends Command {
         return String.format("%.2f", cashflow);
     }
 
+    protected boolean isWithinGivenDates(FinancialEntry entry) {
+        boolean withinStartDate = (start == null || !entry.getDate().isBefore(start));
+        boolean withinEndDate = (end == null || !entry.getDate().isAfter(end));
+        return withinStartDate && withinEndDate;
+    }
+
     /**
      * Method to determine if an entry should be listed out based on its date.
      *
@@ -78,7 +84,7 @@ public class SeeAllEntriesCommand extends Command {
      * @return true if entry should be listed out, false otherwise.
      */
     protected boolean shouldBeIncluded(FinancialEntry entry) {
-        return (end == null || entry.getDate().isBefore(end)) && (start == null || entry.getDate().isAfter(start));
+        return isWithinGivenDates(entry);
     }
 
     /**

--- a/src/main/java/seedu/duke/command/SeeAllExpensesCommand.java
+++ b/src/main/java/seedu/duke/command/SeeAllExpensesCommand.java
@@ -75,7 +75,6 @@ public class SeeAllExpensesCommand extends SeeAllEntriesCommand{
      */
     @Override
     protected boolean shouldBeIncluded(FinancialEntry entry) {
-        return entry instanceof Expense && (end == null || entry.getDate().isBefore(end))
-                && (start == null || entry.getDate().isAfter(start));
+        return (entry instanceof Expense) && isWithinGivenDates(entry);
     }
 }

--- a/src/main/java/seedu/duke/command/SeeAllIncomesCommand.java
+++ b/src/main/java/seedu/duke/command/SeeAllIncomesCommand.java
@@ -61,7 +61,6 @@ public class SeeAllIncomesCommand extends SeeAllEntriesCommand {
      */
     @Override
     protected boolean shouldBeIncluded(FinancialEntry entry) {
-        return entry instanceof Income && (end == null || entry.getDate().isBefore(end))
-                && (start == null || entry.getDate().isAfter(start));
+        return (entry instanceof Income) && isWithinGivenDates(entry);
     }
 }

--- a/src/test/java/seedu/duke/command/SeeAllEntriesCommandTest.java
+++ b/src/test/java/seedu/duke/command/SeeAllEntriesCommandTest.java
@@ -186,11 +186,11 @@ class SeeAllEntriesCommandTest {
 
     /**
      * Test the execute method, specifying that only Entries
-     * between 20/9/2024 and 10/10/24 inclusive should be printed.
+     * between 01/10/2024 and 01/11/24 inclusive should be printed.
      */
     @Test
     void execute_listBeforeAndAfterCertainDate_expectSomeEntries() throws FinanceBuddyException {
-        testCommand = new SeeAllEntriesCommand(LocalDate.of(24, 10, 10), LocalDate.of(24, 11, 1));
+        testCommand = new SeeAllEntriesCommand(LocalDate.of(24, 10, 1), LocalDate.of(24, 11, 1));
         financialList.addEntry(new Expense(3.50, "lunch", LocalDate.of(24, 10, 23),
                 Expense.Category.FOOD));
         financialList.addEntry(new Income(3000.00, "salary", LocalDate.of(24, 11, 2),
@@ -207,13 +207,14 @@ class SeeAllEntriesCommandTest {
         String output = outputStream.toString();
         String expectedOutput = "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded entries:" + System.lineSeparator() +
-                "1. [Income] - allowance $ 100.00 (on 10/10/24) [GIFT]" + System.lineSeparator() +
-                "2. [Expense] - lunch $ 3.50 (on 23/10/24) [FOOD]" + System.lineSeparator() +
+                "1. [Expense] - movie $ 20.00 (on 01/10/24) [ENTERTAINMENT]" + System.lineSeparator() +
+                "2. [Income] - allowance $ 100.00 (on 10/10/24) [GIFT]" + System.lineSeparator() +
+                "3. [Expense] - lunch $ 3.50 (on 23/10/24) [FOOD]" + System.lineSeparator() +
                 System.lineSeparator() +
-                "Net cashflow: $ 96.50" + System.lineSeparator() +
+                "Net cashflow: $ 76.50" + System.lineSeparator() +
                 System.lineSeparator() +
-                "Highest Expense Category: FOOD ($3.50)" + System.lineSeparator() +
-                "Highest Income Category: [GIFT] ($100.00)" + System.lineSeparator()+
+                "Highest Expense Category: ENTERTAINMENT ($20.00)" + System.lineSeparator() +
+                "Highest Income Category: GIFT ($100.00)" + System.lineSeparator()+
                 "--------------------------------------------" + System.lineSeparator();
         assertEquals(
                 expectedOutput.trim().replaceAll("\\s+", " "),

--- a/src/test/java/seedu/duke/command/SeeAllEntriesCommandTest.java
+++ b/src/test/java/seedu/duke/command/SeeAllEntriesCommandTest.java
@@ -95,6 +95,9 @@ class SeeAllEntriesCommandTest {
         assertEquals(expectedOutput, output);
     }
 
+    /**
+     * Test the execute method, specifying that only Entries up to 10/10/24 inclusive should be printed.
+     */
     @Test
     void execute_listBeforeCertainDate_expectSomeEntries() throws FinanceBuddyException {
         testCommand = new SeeAllEntriesCommand(null, LocalDate.of(24, 10, 10));
@@ -111,12 +114,16 @@ class SeeAllEntriesCommandTest {
                 "Here's a list of all recorded entries:" + System.lineSeparator() +
                 "1. [Expense] - dinner $ 4.50 (on 01/09/24)" + System.lineSeparator() +
                 "2. [Expense] - movie ticket $ 20.00 (on 01/10/24)" + System.lineSeparator() +
+                "3. [Income] - allowance $ 100.00 (on 10/10/24)" + System.lineSeparator() +
                 System.lineSeparator() +
-                "Net cashflow: $ -24.50" + System.lineSeparator() +
+                "Net cashflow: $ 75.50" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
         assertEquals(expectedOutput, output);
     }
 
+    /**
+     * Test the execute method, specifying that only Entries starting from 10/10/24 inclusive should be printed.
+     */
     @Test
     void execute_listAfterCertainDate_expectSomeEntries() throws FinanceBuddyException {
         testCommand = new SeeAllEntriesCommand(LocalDate.of(24, 10, 10), null);
@@ -131,14 +138,19 @@ class SeeAllEntriesCommandTest {
         String output = outputStream.toString();
         String expectedOutput = "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded entries:" + System.lineSeparator() +
-                "1. [Expense] - lunch $ 3.50 (on 23/10/24)" + System.lineSeparator() +
-                "2. [Income] - salary $ 3000.00 (on 02/11/24)" + System.lineSeparator() +
+                "1. [Income] - allowance $ 100.00 (on 10/10/24)" + System.lineSeparator() +
+                "2. [Expense] - lunch $ 3.50 (on 23/10/24)" + System.lineSeparator() +
+                "3. [Income] - salary $ 3000.00 (on 02/11/24)" + System.lineSeparator() +
                 System.lineSeparator() +
-                "Net cashflow: $ 2996.50" + System.lineSeparator() +
+                "Net cashflow: $ 3096.50" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
         assertEquals(expectedOutput, output);
     }
 
+    /**
+     * Test the execute method, specifying that only Entries
+     * between 20/9/2024 and 10/10/24 inclusive should be printed.
+     */
     @Test
     void execute_listBeforeAndAfterCertainDate_expectSomeEntries() throws FinanceBuddyException {
         testCommand = new SeeAllEntriesCommand(LocalDate.of(24, 10, 10), LocalDate.of(24, 11, 1));
@@ -153,9 +165,10 @@ class SeeAllEntriesCommandTest {
         String output = outputStream.toString();
         String expectedOutput = "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded entries:" + System.lineSeparator() +
-                "1. [Expense] - lunch $ 3.50 (on 23/10/24)" + System.lineSeparator() +
+                "1. [Income] - allowance $ 100.00 (on 10/10/24)" + System.lineSeparator() +
+                "2. [Expense] - lunch $ 3.50 (on 23/10/24)" + System.lineSeparator() +
                 System.lineSeparator() +
-                "Net cashflow: $ -3.50" + System.lineSeparator() +
+                "Net cashflow: $ 96.50" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
         assertEquals(expectedOutput, output);
     }

--- a/src/test/java/seedu/duke/command/SeeAllExpensesCommandTest.java
+++ b/src/test/java/seedu/duke/command/SeeAllExpensesCommandTest.java
@@ -143,7 +143,7 @@ public class SeeAllExpensesCommandTest {
      */
     @Test
     public void execute_afterDate_printSomeExpenses() throws FinanceBuddyException {
-        FinancialEntry expense1 = new Expense(10.0, "food", LocalDate.of(24, 10, 22),
+        FinancialEntry expense1 = new Expense(9.0, "food", LocalDate.of(24, 10, 22),
                 Expense.Category.FOOD);
         FinancialEntry expense2 = new Expense(5.0, "transport", LocalDate.of(24, 10, 12),
                 Expense.Category.TRANSPORT);
@@ -168,9 +168,9 @@ public class SeeAllExpensesCommandTest {
                 "1. " + expense3 + System.lineSeparator() +
                 "2. " + expense1 + System.lineSeparator() +
                 System.lineSeparator() +
-                "Total expense: $ 20.00" + System.lineSeparator() +
+                "Total expense: $ 19.00" + System.lineSeparator() +
                 System.lineSeparator() +
-                "Highest Expense Category: FOOD ($10.00)" + System.lineSeparator() +
+                "Highest Expense Category: OTHER ($10.00)" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
         assertEquals(expectedOutput, outContent.toString());
     }

--- a/src/test/java/seedu/duke/command/SeeAllExpensesCommandTest.java
+++ b/src/test/java/seedu/duke/command/SeeAllExpensesCommandTest.java
@@ -187,6 +187,10 @@ public class SeeAllExpensesCommandTest {
                 Expense.Category.TRANSPORT);
         FinancialEntry expense3 = new Expense(15.5, "snacks", LocalDate.of(24, 10, 20),
                 Expense.Category.FOOD);
+        FinancialEntry expense4 = new Expense(10.0, "table", LocalDate.of(24, 10, 21),
+                Expense.Category.OTHER);
+        FinancialEntry expense5 = new Expense(7.0, "shampoo", LocalDate.of(24, 10, 15),
+                Expense.Category.UTILITIES);
         FinancialEntry income1 = new Income(10.0, "bonus", LocalDate.of(24, 10, 22),
                 Income.Category.GIFT);
         FinancialEntry income2 = new Income(15.5, "salary", LocalDate.of(24, 10, 12),
@@ -197,15 +201,19 @@ public class SeeAllExpensesCommandTest {
         financialList.addEntry(expense3);
         financialList.addEntry(income1);
         financialList.addEntry(income2);
+        financialList.addEntry(expense4);
+        financialList.addEntry(expense5);
 
         seeAllExpensesCommand = new SeeAllExpensesCommand(LocalDate.of(24, 10, 15), LocalDate.of(24, 10, 21));
         seeAllExpensesCommand.execute(financialList);
 
         String expectedOutput = "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded expenses:" + System.lineSeparator() +
-                "1. " + expense3 + System.lineSeparator() +
+                "1. " + expense5 + System.lineSeparator() +
+                "2. " + expense3 + System.lineSeparator() +
+                "3. " + expense4 + System.lineSeparator() +
                 System.lineSeparator() +
-                "Total expense: $ 15.50" + System.lineSeparator() +
+                "Total expense: $ 32.50" + System.lineSeparator() +
                 System.lineSeparator() +
                 "Highest Expense Category: FOOD ($15.50)" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();

--- a/src/test/java/seedu/duke/command/SeeAllExpensesCommandTest.java
+++ b/src/test/java/seedu/duke/command/SeeAllExpensesCommandTest.java
@@ -95,16 +95,18 @@ public class SeeAllExpensesCommandTest {
     }
 
     /**
-     * Test the execute method, specifying that only Expenses before 20/10/24 should be printed.
+     * Test the execute method, specifying that only Expenses up to 20/10/24 inclusive should be printed.
      */
     @Test
     public void execute_beforeDate_printSomeExpenses() throws FinanceBuddyException {
         FinancialEntry expense1 = new Expense(10.0, "food", LocalDate.of(24,10,22));
         FinancialEntry expense2 = new Expense(5.0, "transport", LocalDate.of(24,10,12));
+        FinancialEntry expense3 = new Expense(10.0, "table", LocalDate.of(24,10,20));
         FinancialEntry income1 = new Income(10.0, "bonus", LocalDate.of(24,10,22));
         FinancialEntry income2 = new Income(15.5, "salary", LocalDate.of(24,10,12));
         financialList.addEntry(expense1);
         financialList.addEntry(expense2);
+        financialList.addEntry(expense3);
         financialList.addEntry(income1);
         financialList.addEntry(income2);
 
@@ -114,23 +116,26 @@ public class SeeAllExpensesCommandTest {
         String expectedOutput = "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded expenses:" + System.lineSeparator() +
                 "1. " + expense2 + System.lineSeparator() +
+                "2. " + expense3 + System.lineSeparator() +
                 System.lineSeparator() +
-                "Total expense: $ 5.00" + System.lineSeparator() +
+                "Total expense: $ 15.00" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
         assertEquals(expectedOutput, outContent.toString());
     }
 
     /**
-     * Test the execute method, specifying that only Expenses after 20/10/24 should be printed.
+     * Test the execute method, specifying that only Expenses starting from 20/10/24 inclusive should be printed.
      */
     @Test
     public void execute_afterDate_printSomeExpenses() throws FinanceBuddyException {
         FinancialEntry expense1 = new Expense(10.0, "food", LocalDate.of(24,10,22));
         FinancialEntry expense2 = new Expense(5.0, "transport", LocalDate.of(24,10,12));
+        FinancialEntry expense3 = new Expense(10.0, "table", LocalDate.of(24,10,20));
         FinancialEntry income1 = new Income(10.0, "bonus", LocalDate.of(24,10,22));
         FinancialEntry income2 = new Income(15.5, "salary", LocalDate.of(24,10,12));
         financialList.addEntry(expense1);
         financialList.addEntry(expense2);
+        financialList.addEntry(expense3);
         financialList.addEntry(income1);
         financialList.addEntry(income2);
 
@@ -139,16 +144,17 @@ public class SeeAllExpensesCommandTest {
 
         String expectedOutput = "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded expenses:" + System.lineSeparator() +
-                "1. " + expense1 + System.lineSeparator() +
+                "1. " + expense3 + System.lineSeparator() +
+                "2. " + expense1 + System.lineSeparator() +
                 System.lineSeparator() +
-                "Total expense: $ 10.00" + System.lineSeparator() +
+                "Total expense: $ 20.00" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
         assertEquals(expectedOutput, outContent.toString());
     }
 
     /**
-     * Test the execute method, specifying that only Incomes
-     * between 15/10/24 and 21/10/24 exclusive should be printed.
+     * Test the execute method, specifying that only Expenses
+     * between 15/10/24 and 21/10/24 inclusive should be printed.
      */
     @Test
     public void execute_beforeAndAfterDate_printSomeExpenses() throws FinanceBuddyException {
@@ -157,20 +163,26 @@ public class SeeAllExpensesCommandTest {
         FinancialEntry income1 = new Income(10.0, "bonus", LocalDate.of(24,10,22));
         FinancialEntry income2 = new Income(15.5, "salary", LocalDate.of(24,10,12));
         FinancialEntry expense3 = new Expense(15.5, "transport", LocalDate.of(24,10,20));
+        FinancialEntry expense4 = new Expense(10.0, "table", LocalDate.of(24,10,21));
+        FinancialEntry expense5 = new Expense(7.0, "chair", LocalDate.of(24,10,15));
         financialList.addEntry(expense1);
         financialList.addEntry(expense2);
         financialList.addEntry(expense3);
         financialList.addEntry(income1);
         financialList.addEntry(income2);
+        financialList.addEntry(expense4);
+        financialList.addEntry(expense5);
 
         seeAllExpensesCommand = new SeeAllExpensesCommand(LocalDate.of(24, 10, 15), LocalDate.of(24, 10, 21));
         seeAllExpensesCommand.execute(financialList);
 
         String expectedOutput = "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded expenses:" + System.lineSeparator() +
-                "1. " + expense3 + System.lineSeparator() +
+                "1. " + expense5 + System.lineSeparator() +
+                "2. " + expense3 + System.lineSeparator() +
+                "3. " + expense4 + System.lineSeparator() +
                 System.lineSeparator() +
-                "Total expense: $ 15.50" + System.lineSeparator() +
+                "Total expense: $ 32.50" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
         assertEquals(expectedOutput, outContent.toString());
     }

--- a/src/test/java/seedu/duke/command/SeeAllIncomesCommandTest.java
+++ b/src/test/java/seedu/duke/command/SeeAllIncomesCommandTest.java
@@ -98,13 +98,13 @@ class SeeAllIncomesCommandTest {
     }
 
     /**
-     * Test the execute method, specifying that only Incomes before 10/10/24 should be printed.
+     * Test the execute method, specifying that only Incomes up to 10/10/24 inclusive should be printed.
      */
     @Test
     void execute_mixedListBeforeCertainDate_expectPrintedIncomes() throws FinanceBuddyException {
         testCommand = new SeeAllIncomesCommand(null, LocalDate.of(24, 10, 10));
         financialList.addEntry(new Expense(3.50, "lunch", LocalDate.of(24, 10, 10)));
-        financialList.addEntry(new Income(3000.00, "salary", LocalDate.of(24, 10, 1)));
+        financialList.addEntry(new Income(3000.00, "salary", LocalDate.of(24, 10, 10)));
         financialList.addEntry(new Expense(4.50, "dinner", LocalDate.of(24, 10, 10)));
         financialList.addEntry(new Expense(20.00, "movie ticket", LocalDate.of(24, 10, 10)));
         financialList.addEntry(new Income(100.00, "allowance", LocalDate.of(24, 11, 2)));
@@ -117,7 +117,7 @@ class SeeAllIncomesCommandTest {
                 "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded incomes:" + System.lineSeparator() +
                 "1. [Income] - ang pow money $ 15.00 (on 12/09/24)" + System.lineSeparator() +
-                "2. [Income] - salary $ 3000.00 (on 01/10/24)" + System.lineSeparator() +
+                "2. [Income] - salary $ 3000.00 (on 10/10/24)" + System.lineSeparator() +
                 System.lineSeparator() +
                 "Total income: $ 3015.00" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
@@ -126,13 +126,13 @@ class SeeAllIncomesCommandTest {
     }
 
     /**
-     * Test the execute method, specifying that only Incomes after 10/10/24 should be printed.
+     * Test the execute method, specifying that only Incomes starting from 10/10/24 inclusive should be printed.
      */
     @Test
     void execute_mixedListAfterCertainDate_expectPrintedIncomes() throws FinanceBuddyException {
         testCommand = new SeeAllIncomesCommand(LocalDate.of(24, 10, 10), null);
         financialList.addEntry(new Expense(3.50, "lunch", LocalDate.of(24, 10, 10)));
-        financialList.addEntry(new Income(3000.00, "salary", LocalDate.of(24, 10, 1)));
+        financialList.addEntry(new Income(3000.00, "salary", LocalDate.of(24, 10, 10)));
         financialList.addEntry(new Expense(4.50, "dinner", LocalDate.of(24, 10, 10)));
         financialList.addEntry(new Expense(20.00, "movie ticket", LocalDate.of(24, 10, 10)));
         financialList.addEntry(new Income(100.00, "allowance", LocalDate.of(24, 11, 2)));
@@ -144,9 +144,10 @@ class SeeAllIncomesCommandTest {
         String expectedOutput =
                 "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded incomes:" + System.lineSeparator() +
-                "1. [Income] - allowance $ 100.00 (on 02/11/24)" + System.lineSeparator() +
+                "1. [Income] - salary $ 3000.00 (on 10/10/24)" + System.lineSeparator() +
+                "2. [Income] - allowance $ 100.00 (on 02/11/24)" + System.lineSeparator() +
                 System.lineSeparator() +
-                "Total income: $ 100.00" + System.lineSeparator() +
+                "Total income: $ 3100.00" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
 
         assertEquals(expectedOutput, output);
@@ -154,7 +155,7 @@ class SeeAllIncomesCommandTest {
 
     /**
      * Test the execute method, specifying that only Incomes
-     * between 20/9/2024 and 10/10/24 exclusive should be printed.
+     * between 20/9/2024 and 10/10/24 inclusive should be printed.
      */
     @Test
     void execute_mixedListBeforeAndAfterCertainDate_expectPrintedIncomes() throws FinanceBuddyException {
@@ -165,6 +166,8 @@ class SeeAllIncomesCommandTest {
         financialList.addEntry(new Expense(20.00, "movie ticket", LocalDate.of(24, 10, 10)));
         financialList.addEntry(new Income(100.00, "allowance", LocalDate.of(24, 11, 2)));
         financialList.addEntry(new Income(15.00, "ang pow money", LocalDate.of(24, 9, 12)));
+        financialList.addEntry(new Income(200.00, "PT money", LocalDate.of(24, 10, 10)));
+        financialList.addEntry(new Income(100.00, "Tuition pay", LocalDate.of(24, 9, 20)));
 
         testCommand.execute(financialList);
 
@@ -172,9 +175,11 @@ class SeeAllIncomesCommandTest {
         String expectedOutput =
                 "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded incomes:" + System.lineSeparator() +
-                "1. [Income] - salary $ 3000.00 (on 01/10/24)" + System.lineSeparator() +
+                "1. [Income] - Tuition pay $ 100.00 (on 20/09/24)" + System.lineSeparator() +
+                "2. [Income] - salary $ 3000.00 (on 01/10/24)" + System.lineSeparator() +
+                "3. [Income] - PT money $ 200.00 (on 10/10/24)" + System.lineSeparator() +
                 System.lineSeparator() +
-                "Total income: $ 3000.00" + System.lineSeparator() +
+                "Total income: $ 3300.00" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();
 
         assertEquals(expectedOutput, output);

--- a/src/test/java/seedu/duke/command/SeeAllIncomesCommandTest.java
+++ b/src/test/java/seedu/duke/command/SeeAllIncomesCommandTest.java
@@ -150,7 +150,7 @@ class SeeAllIncomesCommandTest {
         testCommand = new SeeAllIncomesCommand(LocalDate.of(24, 10, 10), null);
         financialList.addEntry(new Expense(3.50, "lunch", LocalDate.of(24, 10, 10),
                 Expense.Category.FOOD));
-        financialList.addEntry(new Income(3000.00, "salary", LocalDate.of(24, 10, 1),
+        financialList.addEntry(new Income(3000.00, "salary", LocalDate.of(24, 10, 10),
                 Income.Category.SALARY));
         financialList.addEntry(new Expense(4.50, "dinner", LocalDate.of(24, 10, 10),
                 Expense.Category.FOOD));
@@ -189,11 +189,13 @@ class SeeAllIncomesCommandTest {
                 Expense.Category.FOOD));
         financialList.addEntry(new Income(3000.00, "salary", LocalDate.of(24, 10, 1),
                 Income.Category.SALARY));
-        financialList.addEntry(new Expense(4.50, "dinner", LocalDate.of(24, 10, 10),
-                Expense.Category.FOOD));
+        financialList.addEntry(new Income(5.0, "voucher", LocalDate.of(24, 10, 10),
+                Income.Category.GIFT));
         financialList.addEntry(new Expense(20.00, "movie ticket", LocalDate.of(24, 10, 10),
                 Expense.Category.ENTERTAINMENT));
         financialList.addEntry(new Income(100.00, "allowance", LocalDate.of(24, 11, 2),
+                Income.Category.GIFT));
+        financialList.addEntry(new Income(15.00, "birthday money", LocalDate.of(24, 9, 20),
                 Income.Category.GIFT));
         financialList.addEntry(new Income(15.00, "ang pow money", LocalDate.of(24, 9, 12),
                 Income.Category.GIFT));
@@ -203,9 +205,11 @@ class SeeAllIncomesCommandTest {
         String expectedOutput =
                 "--------------------------------------------" + System.lineSeparator() +
                 "Here's a list of all recorded incomes:" + System.lineSeparator() +
-                "1. [Income] - salary $ 3000.00 (on 01/10/24) [SALARY]" + System.lineSeparator() +
+                "1. [Income] - birthday money $ 15.00 (on 20/09/24) [GIFT]" + System.lineSeparator() +
+                "2. [Income] - salary $ 3000.00 (on 01/10/24) [SALARY]" + System.lineSeparator() +
+                "3. [Income] - voucher $ 5.00 (on 10/10/24) [GIFT]" + System.lineSeparator() +
                 System.lineSeparator() +
-                "Total income: $ 3000.00" + System.lineSeparator() +
+                "Total income: $ 3020.00" + System.lineSeparator() +
                 System.lineSeparator() +
                 "Highest Income Category: SALARY ($3000.00)" + System.lineSeparator() +
                 "--------------------------------------------" + System.lineSeparator();


### PR DESCRIPTION
App currently does not include entries which have the same date as the start/end date specified when calling the list command. 
Amended command to include entries on start/end date when calling list.